### PR TITLE
Add batch_before, batch_after and block_end events

### DIFF
--- a/validator/sawtooth_validator/journal/batch_injector.py
+++ b/validator/sawtooth_validator/journal/batch_injector.py
@@ -50,6 +50,48 @@ class BatchInjector(metaclass=abc.ABCMeta):
         """
         raise NotImplementedError()
 
+    @abc.abstractmethod
+    def before_batch(self, previous_block, batch):
+        """Returns an ordered list of batches to inject at the beginning of the
+        block. Can also return None if no batches should be injected.
+
+        Args:
+            previous_block (Block): The previous block.
+            batch (Batch): Current batch.
+
+        Returns:
+            A list of batches to inject.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def after_batch(self, previous_block, batch):
+        """Returns an ordered list of batches to inject at the beginning of the
+        block. Can also return None if no batches should be injected.
+
+        Args:
+            previous_block (Block): The previous block.
+            batch (Batch): Current batch.
+
+        Returns:
+            A list of batches to inject.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def block_end(self, previous_block, batches):
+        """Returns an ordered list of batches to inject at the beginning of the
+        block. Can also return None if no batches should be injected.
+
+        Args:
+            previous_block (Block): The previous block.
+            batches (list<Batch>): The previous batches.
+
+        Returns:
+            A list of batches to inject.
+        """
+        raise NotImplementedError()
+
 
 class UnknownBatchInjectorError(Exception):
     def __init__(self, injector_name):
@@ -85,8 +127,7 @@ class DefaultBatchInjectorFactory:
         """Returns a new batch injector"""
         if injector == "block_info":
             block_info_injector = importlib.import_module(
-                "sawtooth_validator.journal.block_info_injector")
-
+                "sawtooth_validator.journal.injectors.block_info_injector")
             return block_info_injector.BlockInfoInjector(
                 self._state_view_factory, self._signer)
 

--- a/validator/sawtooth_validator/journal/injectors/block_info_injector.py
+++ b/validator/sawtooth_validator/journal/injectors/block_info_injector.py
@@ -102,13 +102,13 @@ class BlockInfoInjector(BatchInjector):
         return [self.create_batch(block_info)]
 
     def before_batch(self, previous_block, batch):
-        pass
+        return []
 
     def after_batch(self, previous_block, batch):
-        pass
+        return []
 
     def block_end(self, previous_block, batches):
-        pass
+        return []
 
 
 def create_block_address(block_num):

--- a/validator/src/journal/block_validator.rs
+++ b/validator/src/journal/block_validator.rs
@@ -22,6 +22,7 @@ use block::Block;
 use execution::execution_platform::{ExecutionPlatform, NULL_STATE_HASH};
 use gossip::permission_verifier::PermissionVerifier;
 use journal::block_scheduler::BlockScheduler;
+use journal::candidate_block::BatchInjectionStage;
 use journal::chain_commit_state::{
     validate_no_duplicate_batches, validate_no_duplicate_transactions,
     validate_transaction_dependencies, ChainCommitStateError,
@@ -714,7 +715,12 @@ impl BlockValidation for OnChainRulesValidation {
                     ))
                 })?;
             let batches: Vec<&Batch> = block.batches.iter().collect();
-            if !enforce_validation_rules(&settings_view, &block.signer_public_key, &batches) {
+            if !enforce_validation_rules(
+                &settings_view,
+                &block.signer_public_key,
+                &batches,
+                &BatchInjectionStage::BlockEnd,
+            ) {
                 return Err(ValidationError::BlockValidationFailure(format!(
                     "Block {} failed validation rules",
                     &block.header_signature

--- a/validator/src/journal/candidate_block.rs
+++ b/validator/src/journal/candidate_block.rs
@@ -39,6 +39,27 @@ use pylogger;
 
 use scheduler::Scheduler;
 
+#[derive(PartialEq, Debug)]
+pub enum BatchInjectionStage {
+    BlockStart,
+    BeforeBatch,
+    AfterBatch,
+    BlockEnd,
+    BlockUnderFormation,
+}
+
+impl BatchInjectionStage {
+    fn value(&self) -> &str {
+        match *self {
+            BatchInjectionStage::BlockStart => "block_start",
+            BatchInjectionStage::BeforeBatch => "before_batch",
+            BatchInjectionStage::AfterBatch => "after_batch",
+            BatchInjectionStage::BlockEnd => "block_end",
+            _ => "",
+        }
+    }
+}
+
 #[derive(Debug)]
 pub enum CandidateBlockError {
     BlockEmpty,
@@ -218,6 +239,55 @@ impl CandidateBlock {
         batches
     }
 
+    pub fn get_injected_batches(
+        &mut self,
+        stage: BatchInjectionStage,
+        batch_opt: Option<&Batch>,
+    ) -> Vec<Batch> {
+        let previous_block = self.previous_block.clone();
+        let pending_batches = self.pending_batches.clone();
+
+        return self.poll_injectors(|injector: &cpython::PyObject| {
+            let gil = cpython::Python::acquire_gil();
+            let py = gil.python();
+            let injector_call = match stage {
+                BatchInjectionStage::BlockStart => {
+                    injector.call_method(py, stage.value(), (previous_block.clone(),), None)
+                }
+                BatchInjectionStage::BeforeBatch | BatchInjectionStage::AfterBatch => injector
+                    .call_method(
+                        py,
+                        stage.value(),
+                        (previous_block.clone(), batch_opt.clone().unwrap()),
+                        None,
+                    ),
+                BatchInjectionStage::BlockEnd => injector.call_method(
+                    py,
+                    stage.value(),
+                    (previous_block.clone(), pending_batches.clone()),
+                    None,
+                ),
+                _ => return vec![],
+            };
+
+            let result = injector_call
+                .expect(&format!("BlockInjector.{} failed", &stage.value()))
+                .extract::<cpython::PyList>(py);
+
+            match result {
+                Ok(injected) => injected.iter(py).collect(),
+                Err(err) => {
+                    pylogger::exception(
+                        py,
+                        &format!("During block injection, calling {}", &stage.value()),
+                        err,
+                    );
+                    vec![]
+                }
+            }
+        });
+    }
+
     pub fn add_batch(&mut self, batch: Batch) {
         let batch_header_signature = batch.header_signature.clone();
 
@@ -239,60 +309,67 @@ impl CandidateBlock {
 
             // Inject blocks at the beginning of a Candidate Block
             if self.pending_batches.is_empty() {
-                let previous_block = self.previous_block.clone();
-                let mut injected_batches = self.poll_injectors(|injector: &cpython::PyObject| {
-                    let gil = cpython::Python::acquire_gil();
-                    let py = gil.python();
-                    match injector
-                        .call_method(py, "block_start", (previous_block.clone(),), None)
-                        .expect("BlockInjector.block_start failed")
-                        .extract::<cpython::PyList>(py)
-                    {
-                        Ok(injected) => injected.iter(py).collect(),
-                        Err(err) => {
-                            pylogger::exception(
-                                py,
-                                "During block injection, calling block_start",
-                                err,
-                            );
-                            vec![]
-                        }
-                    }
-                });
+                let mut injected_batches =
+                    self.get_injected_batches(BatchInjectionStage::BlockStart, None);
                 batches_to_add.append(&mut injected_batches);
             }
 
-            batches_to_add.push(batch);
+            let mut injected_batches_before =
+                self.get_injected_batches(BatchInjectionStage::BeforeBatch, Some(&batch));
 
-            {
-                let batches_to_test = self
-                    .pending_batches
-                    .iter()
-                    .chain(batches_to_add.iter())
-                    .collect::<Vec<_>>();
-                if !validation_rule_enforcer::enforce_validation_rules(
-                    &self.settings_view,
-                    &self.get_signer_public_key_hex(),
-                    &batches_to_test,
-                ) {
-                    return;
-                }
-            }
+            // Inject batches before current batch
+            batches_to_add.append(&mut injected_batches_before);
 
-            for b in batches_to_add {
-                let batch_id = b.header_signature.clone();
-                self.pending_batches.push(b.clone());
-                self.pending_batch_ids.insert(batch_id.clone());
+            // Insert current batch
+            batches_to_add.push(batch.clone());
 
-                let injected = self.injected_batch_ids.contains(batch_id.as_str());
+            let mut injected_batches_after =
+                self.get_injected_batches(BatchInjectionStage::AfterBatch, Some(&batch));
 
-                self.scheduler.add_batch(b, None, injected).unwrap()
-            }
+            // Inject batches after current batch
+            batches_to_add.append(&mut injected_batches_after);
+
+            self.test_and_add_batches(batches_to_add, &BatchInjectionStage::BlockUnderFormation);
         } else {
             debug!(
                 "Dropping batch due to missing dependencies: {}",
                 batch_header_signature.as_str()
             );
+        }
+    }
+
+    fn add_block_end_batches(&mut self) {
+        // Inject blocks at the end of a Candidate Block
+        let batches_to_add = self.get_injected_batches(BatchInjectionStage::BlockEnd, None);
+
+        self.test_and_add_batches(batches_to_add, &BatchInjectionStage::BlockEnd);
+    }
+
+    fn test_and_add_batches(&mut self, batches: Vec<Batch>, stage: &BatchInjectionStage) {
+        {
+            let batches_to_test = self
+                .pending_batches
+                .iter()
+                .chain(batches.iter())
+                .collect::<Vec<_>>();
+            if !validation_rule_enforcer::enforce_validation_rules(
+                &self.settings_view,
+                &self.get_signer_public_key_hex(),
+                &batches_to_test,
+                stage,
+            ) {
+                return;
+            }
+        }
+
+        for b in batches {
+            let batch_id = b.header_signature.clone();
+            self.pending_batches.push(b.clone());
+            self.pending_batch_ids.insert(batch_id.clone());
+
+            let injected = self.injected_batch_ids.contains(batch_id.as_str());
+
+            self.scheduler.add_batch(b, None, injected).unwrap()
         }
     }
 
@@ -335,6 +412,7 @@ impl CandidateBlock {
             return Err(CandidateBlockError::BlockEmpty);
         }
 
+        self.add_block_end_batches();
         self.scheduler.finalize(true).unwrap();
         let execution_results = self.scheduler.complete(true).unwrap().unwrap();
 

--- a/validator/src/journal/mod.rs
+++ b/validator/src/journal/mod.rs
@@ -25,7 +25,7 @@ pub mod block_validator;
 pub mod block_validator_ffi;
 pub mod block_wrapper;
 pub mod block_wrapper_ffi;
-mod candidate_block;
+pub mod candidate_block;
 pub mod chain;
 mod chain_commit_state;
 pub mod chain_ffi;

--- a/validator/src/journal/validation_rule_enforcer.rs
+++ b/validator/src/journal/validation_rule_enforcer.rs
@@ -16,6 +16,7 @@
  */
 
 use batch::Batch;
+use journal::candidate_block::BatchInjectionStage;
 use state::settings_view::SettingsView;
 use transaction::Transaction;
 
@@ -38,14 +39,20 @@ pub fn enforce_validation_rules(
     settings_view: &SettingsView,
     expected_signer: &str,
     batches: &[&Batch],
+    stage: &BatchInjectionStage,
 ) -> bool {
     let rules = settings_view
         .get_setting_str("sawtooth.validator.block_validation_rules", None)
         .expect("Unable to get setting");
-    enforce_rules(rules, expected_signer, batches)
+    enforce_rules(rules, expected_signer, batches, &stage)
 }
 
-fn enforce_rules(rules: Option<String>, expected_signer: &str, batches: &[&Batch]) -> bool {
+fn enforce_rules(
+    rules: Option<String>,
+    expected_signer: &str,
+    batches: &[&Batch],
+    stage: &BatchInjectionStage,
+) -> bool {
     if rules.is_none() {
         return true;
     }
@@ -61,9 +68,9 @@ fn enforce_rules(rules: Option<String>, expected_signer: &str, batches: &[&Batch
             if rule_type == "NofX" {
                 valid = do_nofx(&transactions, &arguments);
             } else if rule_type == "XatY" {
-                valid = do_xaty(&transactions, &arguments);
+                valid = do_xaty(&transactions, &arguments, &stage);
             } else if rule_type == "local" {
-                valid = do_local(&transactions, expected_signer, &arguments);
+                valid = do_local(&transactions, expected_signer, &arguments, &stage);
             }
 
             if !valid {
@@ -134,10 +141,10 @@ fn do_nofx(transactions: &[&Transaction], arguments: &[&str]) -> bool {
 /// would not be a transaction of type X at Y and the block would be
 /// invalid. For example, the string "XatY:intkey,0" means the first
 /// transaction in the block must be an intkey transaction.
-fn do_xaty(transactions: &[&Transaction], arguments: &[&str]) -> bool {
+fn do_xaty(transactions: &[&Transaction], arguments: &[&str], stage: &BatchInjectionStage) -> bool {
     let (family, position) = if arguments.len() == 2 {
         let family = arguments[0].trim();
-        let position: usize = match arguments[1].trim().parse() {
+        let position: isize = match arguments[1].trim().parse() {
             Ok(i) => i,
             Err(_) => {
                 warn!(
@@ -156,21 +163,25 @@ fn do_xaty(transactions: &[&Transaction], arguments: &[&str]) -> bool {
         return true;
     };
 
-    if position >= transactions.len() {
-        debug!(
-            "Block does not have enough transactions to valid this rule XatY:{:?}",
-            arguments
-        );
-        return false;
+    if stage != &BatchInjectionStage::BlockEnd {
+        return true;
     }
 
-    let txn = transactions[position];
-    if txn.family_name != family {
-        debug!(
-            "Transaction at position {} is not of type {}",
-            position, family
-        );
-        return false;
+    let txn = get_transaction_from_index(&transactions, position, "XatY".to_string());
+
+    match txn {
+        Some(transaction) => {
+            if transaction.family_name != family {
+                warn!(
+                    "Transaction at position {} is not of type {}",
+                    position, family
+                );
+                return false;
+            }
+        }
+        _ => {
+            return false;
+        }
     }
 
     true
@@ -181,8 +192,13 @@ fn do_xaty(transactions: &[&Transaction], arguments: &[&str]) -> bool {
 /// rule on each. This rule is useful in combination with the other rules
 /// to ensure a client is not submitting transactions that should only be
 /// injected by the winning validator.
-fn do_local(transactions: &[&Transaction], expected_signer: &str, arguments: &[&str]) -> bool {
-    let indices: Result<Vec<usize>, _> = arguments.iter().map(|s| s.trim().parse()).collect();
+fn do_local(
+    transactions: &[&Transaction],
+    expected_signer: &str,
+    arguments: &[&str],
+    stage: &BatchInjectionStage,
+) -> bool {
+    let indices: Result<Vec<isize>, _> = arguments.iter().map(|s| s.trim().parse()).collect();
 
     if indices.is_err() || indices.as_ref().unwrap().is_empty() {
         warn!(
@@ -194,24 +210,23 @@ fn do_local(transactions: &[&Transaction], expected_signer: &str, arguments: &[&
     }
 
     for index in indices.unwrap() {
-        if index >= transactions.len() {
-            debug!(
-                "Ignore, Block does not have enough transactions to validate this rule local: {}",
-                index
-            );
-            continue;
-        }
-
-        if transactions[index].signer_public_key != expected_signer {
-            debug!(
-                "Transaction at  position {} was not signed by the expected signer.",
-                index
-            );
-            return false;
+        if stage == &BatchInjectionStage::BlockEnd {
+            let txn = get_transaction_from_index(&transactions, index, "local".to_string());
+            match txn {
+                Some(transaction) => {
+                    if transaction.signer_public_key != expected_signer {
+                        warn!(
+                            "Transaction at position {} was not signed by the expected signer.\n{:?}",
+                            index, &transaction,
+                        );
+                        return false;
+                    }
+                }
+                _ => continue,
+            }
         }
     }
-
-    true
+    return true;
 }
 
 /// Splits up a rule string in the form of "<rule_type>:<rule_arg>,*"
@@ -227,11 +242,43 @@ fn parse_rule(rule: &str) -> Option<(&str, Vec<&str>)> {
     Some((rule_type.trim(), rule_args))
 }
 
+/// Get transaction from the given index
+fn get_transaction_from_index(
+    transactions: &[&Transaction],
+    index: isize,
+    rule: String,
+) -> Option<Transaction> {
+    let absolute_index: usize = if index < 0 {
+        (index * -1) as usize
+    } else {
+        index as usize
+    };
+    if (index < 0 && absolute_index > transactions.len())
+        || (index >= 0 && absolute_index >= transactions.len())
+    {
+        debug!(
+            "Ignore, Block does not have enough transactions to validate this rule {}: {}",
+            rule, index
+        );
+        return None;
+    }
+
+    if index < 0 {
+        return Some(transactions[transactions.len() - absolute_index].clone());
+    }
+
+    return Some(transactions[absolute_index].clone());
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use batch::Batch;
     use transaction::Transaction;
+
+    /// BatchInjectionStage::BlockEnd should be used in the enforce_rules
+    /// method to simulate the full set of batches to be added to a block
+    /// You should use this in order to validate every rule
 
     /// Test that if no validation rules are set, the block is valid.
     #[test]
@@ -240,7 +287,8 @@ mod tests {
         assert!(enforce_rules(
             None,
             "pub_key",
-            &batches.iter().collect::<Vec<_>>()
+            &batches.iter().collect::<Vec<_>>(),
+            &BatchInjectionStage::BlockEnd,
         ));
     }
 
@@ -255,17 +303,20 @@ mod tests {
         assert!(enforce_rules(
             Some("NofX:1,intkey".to_string()),
             "pub_key",
-            &batches.iter().collect::<Vec<_>>()
+            &batches.iter().collect::<Vec<_>>(),
+            &BatchInjectionStage::BlockEnd,
         ));
         assert!(!enforce_rules(
             Some("NofX:0,intkey".to_string()),
             "pub_key",
-            &batches.iter().collect::<Vec<_>>()
+            &batches.iter().collect::<Vec<_>>(),
+            &BatchInjectionStage::BlockEnd,
         ));
         assert!(enforce_rules(
             Some("NofX:0".to_string()),
             "pub_key",
-            &batches.iter().collect::<Vec<_>>()
+            &batches.iter().collect::<Vec<_>>(),
+            &BatchInjectionStage::BlockEnd,
         ));
     }
 
@@ -280,17 +331,20 @@ mod tests {
         assert!(enforce_rules(
             Some("XatY:intkey,0".to_string()),
             "pub_key",
-            &batches.iter().collect::<Vec<_>>()
+            &batches.iter().collect::<Vec<_>>(),
+            &BatchInjectionStage::BlockEnd,
         ));
         assert!(!enforce_rules(
             Some("XatY:blockinfo,0".to_string()),
             "pub_key",
-            &batches.iter().collect::<Vec<_>>()
+            &batches.iter().collect::<Vec<_>>(),
+            &BatchInjectionStage::BlockEnd,
         ));
         assert!(enforce_rules(
             Some("XatY:0".to_string()),
             "pub_key",
-            &batches.iter().collect::<Vec<_>>()
+            &batches.iter().collect::<Vec<_>>(),
+            &BatchInjectionStage::BlockEnd,
         ));
     }
 
@@ -306,17 +360,20 @@ mod tests {
         assert!(enforce_rules(
             Some("local:0".to_string()),
             "pub_key",
-            &batches.iter().collect::<Vec<_>>()
+            &batches.iter().collect::<Vec<_>>(),
+            &BatchInjectionStage::BlockEnd,
         ));
         assert!(!enforce_rules(
             Some("local:0".to_string()),
             "another_pub_key",
-            &batches.iter().collect::<Vec<_>>()
+            &batches.iter().collect::<Vec<_>>(),
+            &BatchInjectionStage::BlockEnd,
         ));
         assert!(enforce_rules(
             Some("local".to_string()),
             "pub_key",
-            &batches.iter().collect::<Vec<_>>()
+            &batches.iter().collect::<Vec<_>>(),
+            &BatchInjectionStage::BlockEnd,
         ));
     }
 
@@ -328,7 +385,8 @@ mod tests {
         assert!(enforce_rules(
             Some("NofX:1,intkey;XatY:intkey,0;local:0".to_string()),
             "pub_key",
-            &batches.iter().collect::<Vec<_>>()
+            &batches.iter().collect::<Vec<_>>(),
+            &BatchInjectionStage::BlockEnd,
         ));
     }
 
@@ -340,7 +398,8 @@ mod tests {
         assert!(!enforce_rules(
             Some("NofX:0,intkey;XatY:intkey,0;local:0".to_string()),
             "pub_key",
-            &batches.iter().collect::<Vec<_>>()
+            &batches.iter().collect::<Vec<_>>(),
+            &BatchInjectionStage::BlockEnd,
         ));
     }
 
@@ -353,7 +412,8 @@ mod tests {
         assert!(!enforce_rules(
             Some("NofX:1,intkey;XatY:blockinfo,0;local:0".to_string()),
             "pub_key",
-            &batches.iter().collect::<Vec<_>>()
+            &batches.iter().collect::<Vec<_>>(),
+            &BatchInjectionStage::BlockEnd,
         ));
     }
 
@@ -366,7 +426,67 @@ mod tests {
         assert!(!enforce_rules(
             Some("NofX:1,intkey;XatY:intkey,0;local:0".to_string()),
             "not_same_pubkey",
-            &batches.iter().collect::<Vec<_>>()
+            &batches.iter().collect::<Vec<_>>(),
+            &BatchInjectionStage::BlockEnd,
+        ));
+    }
+
+    /// Test that if multiple rules are set for multiple batch injectors,
+    /// they are all checked correctly.
+    ///     1. Expected valid XatY rules for negative position
+    ///     2. Expected valid NofX and muliple valid XatY rules
+    #[test]
+    fn test_all_at_once_multiple_injectors() {
+        let batches = make_batches(&["intkey", "block_info"], "pub_key");
+        assert!(enforce_rules(
+            Some(
+                "NofX:1,intkey;XatY:intkey,0;NofX:1,block_info;XatY:block_info,-1;local:0"
+                    .to_string()
+            ),
+            "pub_key",
+            &batches.iter().collect::<Vec<_>>(),
+            &BatchInjectionStage::BlockEnd,
+        ));
+        let even_more_batches = make_batches(
+            &[
+                "block_info",
+                "intkey",
+                "random_injector",
+                "random_injector",
+                "random_injector",
+                "random_injector",
+            ],
+            "pub_key",
+        );
+        assert!(enforce_rules(
+            Some(
+                "NofX:1,block_info;
+                XatY:block_info,0;
+                NofX:4,random_injector;
+                XatY:random_injector,5;
+                XatY:random_injector,4;
+                XatY:random_injector,3;
+                XatY:random_injector,2;
+                local:0,-1
+                "
+                .to_string()
+            ),
+            "pub_key",
+            &even_more_batches.iter().collect::<Vec<_>>(),
+            &BatchInjectionStage::BlockEnd,
+        ));
+    }
+
+    /// Test that if multiple local rules are set, they are all checked correctly.
+    /// Expected valid local rules for negative positions
+    #[test]
+    fn test_multiple_locals() {
+        let batches = make_batches(&["intkey"], "pub_key");
+        assert!(enforce_rules(
+            Some("local:0,-1".to_string()),
+            "pub_key",
+            &batches.iter().collect::<Vec<_>>(),
+            &BatchInjectionStage::BlockEnd,
         ));
     }
 

--- a/validator/src/state/settings_view.rs
+++ b/validator/src/state/settings_view.rs
@@ -207,6 +207,14 @@ mod tests {
             setting_entry("my.setting", "10"),
             setting_entry("my.setting.list", "10,11,12"),
             setting_entry("my.other.list", "13;14;15"),
+
+            setting_entry("sawtooth.validator.block_validation_rules", 
+                "NofX:1,injector_1;XatY:injector_1,0;
+                NofX:1,injector_2;XatY:injector_2,-1;
+                NofX:1,injector_3;XatY:injector_3,1;
+                NofX:1,injector_4;XatY:injector_4,2;
+                local:0,-1,1,2"
+            ),
         ]);
 
         let settings_view = SettingsView::new(Box::new(mock_reader));
@@ -266,6 +274,11 @@ mod tests {
                     .collect::<Result<Vec<u32>, SettingsViewError>>())
                 .unwrap()
         );
+
+        let block_validation_rules = settings_view
+            .get_setting_str("sawtooth.validator.block_validation_rules", None)
+            .unwrap();
+        assert!(block_validation_rules.is_some());
     }
 
     fn setting_entry(key: &str, value: &str) -> (String, Vec<u8>) {


### PR DESCRIPTION
Add support for the batch_before, batch_after and block_end injector events.
Add support for negative values in the "XatY" and "local" rules in the setting "sawtooth.validator.block_validation_rules".
Implement missing abtract methods in the Batch Injector Factory in the python implementation.
Move injectors into a dedicated folder.

This will change the "block_validation_rules" to only be applied at the end of the block in order to avoid conflicts and multiple validations of previously aproved batches.

Co-authored-by: Micaelsf <micael.ferreira@voidsoftware.com>
Signed-off-by: AntonioBranco <antonio.branco@voidsoftware.com>